### PR TITLE
FIX: Filename casing of skeletonState import on Ubuntu

### DIFF
--- a/src/crowd-2d-skeleton.js
+++ b/src/crowd-2d-skeleton.js
@@ -33,7 +33,7 @@ import {
   uniqueSkeletonColorsSchema
 } from './validationSchemas/uniqueSkeletonColorsSchema';
 import { KeypointState } from './keypointState';
-import { SkeletonState } from './SkeletonState';
+import { SkeletonState } from './skeletonState';
 import { isNil, isEmpty, isNull, isEqual, get, last, isArray } from 'lodash';
 import { COLORS, KEYPOINT_HOTKEYS, KEYPOINT_DRAW_STYLES } from './constants';
 


### PR DESCRIPTION
**Description of changes:**
Fixes a filename casing mismatch for skeletonState.js import in crowd-2d-skeleton.js so it resolves correctly on Ubuntu.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.